### PR TITLE
Fixed: Add Patient Form in Patients Dashboard Portal

### DIFF
--- a/Back-End/api_router/patient.py
+++ b/Back-End/api_router/patient.py
@@ -64,7 +64,14 @@ async def get_all_patients():
         if result.data is None:
             return []
 
-        return result.data
+        # Ensure dates/datetimes are JSON serializable
+        def _serialize_row(r):
+            for k, v in list(r.items()):
+                if isinstance(v, (date, datetime)):
+                    r[k] = v.isoformat()
+            return r
+
+        return [_serialize_row(r) for r in result.data]
     except Exception as exc:
         logger.exception("Failed to retrieve patients: %s", exc)
         raise HTTPException(
@@ -91,6 +98,11 @@ async def get_patient(patient_id: str):
                 detail=f"Patient with id {patient_id} not found",
             )
 
+        # Serialize date/datetime fields to ISO strings
+        for k, v in list(result.data.items()):
+            if isinstance(v, (date, datetime)):
+                result.data[k] = v.isoformat()
+
         return result.data
     except HTTPException:
         raise
@@ -113,6 +125,10 @@ async def create_patient(patient: PatientCreate):
         # Convert patient data to dict for database insertion
         patient_data = patient.model_dump()
 
+        # Ensure date fields are JSON serializable before sending to Supabase
+        if isinstance(patient_data.get("dob"), (date, datetime)):
+            patient_data["dob"] = patient_data["dob"].isoformat()
+
         result = supabase.table("patients").insert(patient_data).execute()
 
         if not result.data or len(result.data) == 0:
@@ -121,7 +137,12 @@ async def create_patient(patient: PatientCreate):
                 detail="Failed to create patient",
             )
 
-        return result.data[0]
+        created = result.data[0]
+        for k, v in list(created.items()):
+            if isinstance(v, (date, datetime)):
+                created[k] = v.isoformat()
+
+        return created
     except HTTPException:
         raise
     except Exception as exc:
@@ -144,6 +165,10 @@ async def update_patient(patient_id: str, patient: PatientUpdate):
                 detail="No data provided for update",
             )
 
+        # Convert date fields to serializable strings and add updated timestamp
+        if isinstance(updated_values.get("dob"), (date, datetime)):
+            updated_values["dob"] = updated_values["dob"].isoformat()
+
         # Add updated timestamp
         updated_values["updated_at"] = datetime.utcnow().isoformat()
 
@@ -160,7 +185,12 @@ async def update_patient(patient_id: str, patient: PatientUpdate):
                 detail=f"Patient with id {patient_id} not found",
             )
 
-        return result.data[0]
+        updated = result.data[0]
+        for k, v in list(updated.items()):
+            if isinstance(v, (date, datetime)):
+                updated[k] = v.isoformat()
+
+        return updated
     except HTTPException:
         raise
     except Exception as exc:

--- a/Front-End/src/features/patients/PatientList.tsx
+++ b/Front-End/src/features/patients/PatientList.tsx
@@ -44,7 +44,45 @@ export function PatientList() {
     setIsCreating(true);
     setCreateError(null);
 
-    const result = await createPatient(patientData);
+    // Normalize phone: strip non-digit characters and validate presence/length
+    const normalizedPhone = patientData.phone
+      ? patientData.phone.replace(/\D/g, "")
+      : "";
+
+    // Backend requires primary_phone (mapped from phone)
+    if (!normalizedPhone) {
+      setCreateError("Phone number is required.");
+      setIsCreating(false);
+      return;
+    }
+
+    // Basic length check (assuming minimum 10 digits for a valid phone number) 
+    if (normalizedPhone.length < 10) {
+      setCreateError("Phone number must have at least 10 digits.");
+      setIsCreating(false);
+      return;
+    }
+
+    // Backend requires address with min_length 5 for validity
+    if (!patientData.address || patientData.address.trim().length < 5) {
+      setCreateError("Address is required and must be at least 5 characters.");
+      setIsCreating(false);
+      return;
+    }
+
+    // Date of birth is required for all patients to be created
+    if (!patientData.date_of_birth) {
+      setCreateError("Date of birth is required.");
+      setIsCreating(false);
+      return;
+    }
+
+    const payload: PatientCreateRequest = {
+      ...patientData,
+      phone: normalizedPhone,
+    };
+
+    const result = await createPatient(payload);
 
     if (result.success) {
       setShowCreateModal(false);

--- a/Front-End/src/services/patientService.ts
+++ b/Front-End/src/services/patientService.ts
@@ -27,7 +27,7 @@ export interface PatientCreateRequest {
   emergency_contact?: string;
 }
 
-export interface PatientUpdateRequest extends Partial<PatientCreateRequest> {}
+export interface PatientUpdateRequest extends Partial<PatientCreateRequest> { }
 
 // Patient Service Functions
 export const patientService = {
@@ -41,14 +41,36 @@ export const patientService = {
   },
 
   async create(data: PatientCreateRequest): Promise<ApiResponse<Patient>> {
-    return api.post<Patient>("/patients/", data);
+    // Backend validation expects `dob` and `primary_phone` field names. Throws an error code 500 and 244 otherwise
+    // Map our front-end shape (date_of_birth, phone) to the backend contract.
+    const payload: any = {
+      ...data,
+      dob: data.date_of_birth,
+      primary_phone: data.phone,
+    };
+    // Remove originals inputted values if backend does not accept them alongside mapped keys
+    delete payload.date_of_birth;
+    delete payload.phone;
+
+    return api.post<Patient>("/patients/", payload);
   },
 
   async update(
     id: string,
     data: PatientUpdateRequest
   ): Promise<ApiResponse<Patient>> {
-    return api.patch<Patient>(`/patients/${id}`, data);
+    // Map optional fields for update as well, and will do the same as was done with create (remove originals)
+    const payload: any = { ...data };
+    if (payload.date_of_birth !== undefined) {
+      payload.dob = (payload as any).date_of_birth;
+      delete payload.date_of_birth;
+    }
+    if (payload.phone !== undefined) {
+      payload.primary_phone = (payload as any).phone;
+      delete payload.phone;
+    }
+
+    return api.patch<Patient>(`/patients/${id}`, payload);
   },
 
   async delete(id: string): Promise<ApiResponse<void>> {


### PR DESCRIPTION
Fixed the issue where patients could not be added by form via the patients portal on the website, would originally throw Error 422 unreachable Entity, and error 500.  Also added in some data validity checks to ensure values are acceptable character limit, and data fields are not empty.